### PR TITLE
Trường Sa district

### DIFF
--- a/history/states/1248-Dao Truong Sa Lon.txt
+++ b/history/states/1248-Dao Truong Sa Lon.txt
@@ -14,7 +14,7 @@ state={
 			}
 
 		}
-		add_claim_by = VIN
+		add_core_of = VIN
 		add_claim_by = PRC
 		add_claim_by = CHI
 	}
@@ -22,7 +22,7 @@ state={
 	provinces={
 		14674 
 	}
-	manpower=1
+	manpower=195
 	buildings_max_level_factor=1.000
 	state_category=state_default
 	local_supplies=0.000


### PR DESCRIPTION
Trường Sa is an island district of Khánh Hòa province in the South Central Coast region of Vietnam.